### PR TITLE
fix: correct otelzap import path in pkg/moni

### DIFF
--- a/pkg/moni/database.go
+++ b/pkg/moni/database.go
@@ -10,8 +10,8 @@ import (
 	"github.com/CodeMonkeyCybersecurity/eos/pkg/eos_io"
 	"github.com/CodeMonkeyCybersecurity/eos/pkg/execute"
 	"github.com/CodeMonkeyCybersecurity/eos/pkg/interaction"
+	"github.com/uptrace/opentelemetry-go-extra/otelzap"
 	"go.uber.org/zap"
-	"go.uber.org/zap/otelzap"
 )
 
 // ConfigureDatabase configures database models and prompts

--- a/pkg/moni/ssl.go
+++ b/pkg/moni/ssl.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/CodeMonkeyCybersecurity/eos/pkg/eos_io"
 	"github.com/CodeMonkeyCybersecurity/eos/pkg/execute"
+	"github.com/uptrace/opentelemetry-go-extra/otelzap"
 	"go.uber.org/zap"
-	"go.uber.org/zap/otelzap"
 	"gopkg.in/yaml.v3"
 )
 

--- a/pkg/moni/verification.go
+++ b/pkg/moni/verification.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/CodeMonkeyCybersecurity/eos/pkg/eos_io"
 	"github.com/CodeMonkeyCybersecurity/eos/pkg/execute"
+	"github.com/uptrace/opentelemetry-go-extra/otelzap"
 	"go.uber.org/zap"
-	"go.uber.org/zap/otelzap"
 )
 
 // WaitForService waits for a service to become ready

--- a/pkg/moni/worker.go
+++ b/pkg/moni/worker.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/CodeMonkeyCybersecurity/eos/pkg/eos_io"
 	"github.com/CodeMonkeyCybersecurity/eos/pkg/execute"
+	"github.com/uptrace/opentelemetry-go-extra/otelzap"
 	"go.uber.org/zap"
-	"go.uber.org/zap/otelzap"
 )
 
 // RunWorker runs the Moni initialization worker


### PR DESCRIPTION
Changed import path from incorrect 'go.uber.org/zap/otelzap' to correct 'github.com/uptrace/opentelemetry-go-extra/otelzap' in 4 files:
- pkg/moni/database.go
- pkg/moni/ssl.go
- pkg/moni/verification.go
- pkg/moni/worker.go

The dependency already exists in go.mod at line 49, but the import paths were using the wrong package name, causing build failures with: "no required module provides package go.uber.org/zap/otelzap"

This resolves the eos self-update build failure.